### PR TITLE
fix(sync): fetch status until connection is established or failed to establish

### DIFF
--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -99,6 +99,9 @@ func connect_to_server():
 	var connect = stream.connect_to_host(ip, port)
 	stream.set_no_delay(true) # TODO check if this improves performance or not
 	stream.poll()
+	# Fetch the status until it is either connected (2) or failed to connect (3)
+	while stream.get_status() < 2:
+		status = stream.poll()
 	return stream.get_status() == 2
 
 func _get_args():

--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -101,7 +101,7 @@ func connect_to_server():
 	stream.poll()
 	# Fetch the status until it is either connected (2) or failed to connect (3)
 	while stream.get_status() < 2:
-		status = stream.poll()
+		stream.poll()
 	return stream.get_status() == 2
 
 func _get_args():


### PR DESCRIPTION
This will make sure that the function is not returning while still in "connecting" state (1) but only when connection suceeded (2) or failed (3).
Needed this to work on my macbook.