### PR TITLE
Update sync.gd to enable changing action_repeat value in Godot Inspector

### DIFF
--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -1,7 +1,7 @@
 extends Node
 # --fixed-fps 2000 --disable-render-loop
-@export var action_repeat := 8
-@export var speed_up = 1
+@export_range(1, 10, 1, "or_greater") var action_repeat := 8
+@export_range(1, 10, 1, "or_greater") var speed_up = 1
 @export var onnx_model_path := ""
 
 @onready var start_time = Time.get_ticks_msec()
@@ -10,7 +10,6 @@ const MAJOR_VERSION := "0"
 const MINOR_VERSION := "3" 
 const DEFAULT_PORT := "11008"
 const DEFAULT_SEED := "1"
-const DEFAULT_ACTION_REPEAT := "8"
 var stream : StreamPeerTCP = null
 var connected = false
 var message_center
@@ -232,7 +231,7 @@ func _set_seed():
 	seed(_seed)
 
 func _set_action_repeat():
-	action_repeat = args.get("action_repeat", DEFAULT_ACTION_REPEAT).to_int()
+	action_repeat = args.get("action_repeat", str(action_repeat)).to_int()
 	
 func disconnect_from_server():
 	stream.disconnect_from_host()


### PR DESCRIPTION
Previously changing the value of action_repeat in inspector did not take effect (it would still be the default 8), this update fixes that.

Also, now the minimum allowed value for action_repeat and speed_up in Godot Inspector is set to 1.