### PR TITLE
Multiple changes to fix onnx inference and export issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ export_presets.cfg
 .mono/
 data_*/
 mono_crash.*.json
+.vs/

--- a/Godot RL Agents.csproj
+++ b/Godot RL Agents.csproj
@@ -1,13 +1,10 @@
-<Project Sdk="Godot.NET.Sdk/4.0.0">
+<Project Sdk="Godot.NET.Sdk/4.0.3">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RootNamespace>GodotRLAgents</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.14.1" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.14.1" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.14.1" />
-    <PackageReference Include="System.Numerics.Tensors" Version="0.1.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.15.1" />
   </ItemGroup>
 </Project>

--- a/Godot RL Agents.sln
+++ b/Godot RL Agents.sln
@@ -1,12 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Godot RL Agents", "Godot RL Agents.csproj", "{055E8CBC-A3EC-41A8-BC53-EC3010682AE4}"
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33530.505
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Godot RL Agents", "Godot RL Agents.csproj", "{055E8CBC-A3EC-41A8-BC53-EC3010682AE4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-	Debug|Any CPU = Debug|Any CPU
-	ExportDebug|Any CPU = ExportDebug|Any CPU
-	ExportRelease|Any CPU = ExportRelease|Any CPU
+		Debug|Any CPU = Debug|Any CPU
+		ExportDebug|Any CPU = ExportDebug|Any CPU
+		ExportRelease|Any CPU = ExportRelease|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{055E8CBC-A3EC-41A8-BC53-EC3010682AE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -15,5 +18,8 @@ Global
 		{055E8CBC-A3EC-41A8-BC53-EC3010682AE4}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
 		{055E8CBC-A3EC-41A8-BC53-EC3010682AE4}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
 		{055E8CBC-A3EC-41A8-BC53-EC3010682AE4}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/addons/godot_rl_agents/onnx/csharp/ONNXInference.cs
+++ b/addons/godot_rl_agents/onnx/csharp/ONNXInference.cs
@@ -1,93 +1,97 @@
 using Godot;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
+using System.Collections.Generic;
+using System.Linq;
 
-namespace GodotONNX{
-	/// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/ONNXInference/*'/>
- 	public partial class ONNXInference : Node
+namespace GodotONNX
 {
-		
-	private InferenceSession session;
-	/// <summary>
-	/// Path to the ONNX model. Use Initialize to change it. 
-	/// </summary>
-	private string modelPath;
-	private int batchSize;
+    /// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/ONNXInference/*'/>
+    public partial class ONNXInference : Node
+    {
 
-	private SessionOptions SessionOpt;
+        private InferenceSession session;
+        /// <summary>
+        /// Path to the ONNX model. Use Initialize to change it. 
+        /// </summary>
+        private string modelPath;
+        private int batchSize;
 
-	//init function
-/// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/Initialize/*'/>
-	public void Initialize(string Path, int BatchSize)
-	{
-		modelPath = Path;
-		batchSize = BatchSize;
-		SessionConfigurator.SystemCheck();
-		SessionOpt = SessionConfigurator.GetSessionOptions();
-		session = LoadModel(modelPath);
+        private SessionOptions SessionOpt;
 
-	}
-/// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/Run/*'/>
-	public Godot.Collections.Dictionary<string, Godot.Collections.Array<float>> RunInference(Godot.Collections.Array<float> obs, int state_ins)
-	{
-		//Current model: Any (Godot Rl Agents)
-		//Expects a tensor of shape [batch_size, input_size] type float named obs and a tensor of shape [batch_size] type float named state_ins
-		
-		//Fill the input tensors
-		// create span from inputSize
-		var span = new float[obs.Count]; //There's probably a better way to do this
-		for (int i = 0; i < obs.Count; i++)
-		{
-			span[i] = obs[i];
-		}
-				
-		IReadOnlyCollection<NamedOnnxValue> inputs = new List<NamedOnnxValue> 
-			{
-			NamedOnnxValue.CreateFromTensor("obs", new DenseTensor<float>(span, new int[] { batchSize, obs.Count })),
-			NamedOnnxValue.CreateFromTensor("state_ins", new DenseTensor<float>(new float[] { state_ins }, new int[] { batchSize }))
-			}; 
-		IReadOnlyCollection<string> outputNames = new List<string> { "output", "state_outs" }; //ONNX is sensible to these names, as well as the input names
+        //init function
+        /// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/Initialize/*'/>
+        public void Initialize(string Path, int BatchSize)
+        {
+            modelPath = Path;
+            batchSize = BatchSize;
+            SessionOpt = SessionConfigurator.GetSessionOptions();
+            session = LoadModel(modelPath);
 
-			IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results;
-		
-		try{
-			results = session.Run(inputs, outputNames);
-		}
-		catch (OnnxRuntimeException e) {
-			//This error usually means that the model is not compatible with the input, beacause of the input shape (size)
-			GD.Print("Error at inference: ", e);
-			return null;
-		}
-		//Can't convert IEnumerable<float> to Variant, so we have to convert it to an array or something
-		Godot.Collections.Dictionary<string, Godot.Collections.Array<float>> output = new Godot.Collections.Dictionary<string, Godot.Collections.Array<float>>();
-		DisposableNamedOnnxValue output1 = results.First();
-		DisposableNamedOnnxValue output2 = results.Last();
-		Godot.Collections.Array<float> output1Array = new Godot.Collections.Array<float>();
-		Godot.Collections.Array<float> output2Array = new Godot.Collections.Array<float>();
+        }
+        /// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/Run/*'/>
+        public Godot.Collections.Dictionary<string, Godot.Collections.Array<float>> RunInference(Godot.Collections.Array<float> obs, int state_ins)
+        {
+            //Current model: Any (Godot Rl Agents)
+            //Expects a tensor of shape [batch_size, input_size] type float named obs and a tensor of shape [batch_size] type float named state_ins
 
-		foreach (float f in output1.AsEnumerable<float>()) {
-			output1Array.Add(f);
-		}
+            //Fill the input tensors
+            // create span from inputSize
+            var span = new float[obs.Count]; //There's probably a better way to do this
+            for (int i = 0; i < obs.Count; i++)
+            {
+                span[i] = obs[i];
+            }
 
-		foreach (float f in output2.AsEnumerable<float>()) {
-			output2Array.Add(f);
-		}
+            IReadOnlyCollection<NamedOnnxValue> inputs = new List<NamedOnnxValue>
+            {
+            NamedOnnxValue.CreateFromTensor("obs", new DenseTensor<float>(span, new int[] { batchSize, obs.Count })),
+            NamedOnnxValue.CreateFromTensor("state_ins", new DenseTensor<float>(new float[] { state_ins }, new int[] { batchSize }))
+            };
+            IReadOnlyCollection<string> outputNames = new List<string> { "output", "state_outs" }; //ONNX is sensible to these names, as well as the input names
 
-		output.Add(output1.Name, output1Array);
-		output.Add(output2.Name, output2Array);
-		
-		//Output is a dictionary of arrays, ex: { "output" : [0.1, 0.2, 0.3, 0.4, ...], "state_outs" : [0.5, ...]}
-		return output;
-	}	
-/// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/Load/*'/>
-	public InferenceSession LoadModel(string Path) 
-	{
-		Godot.FileAccess file = FileAccess.Open(Path, Godot.FileAccess.ModeFlags.Read);
-		byte[] model = file.GetBuffer((int)file.GetLength());
-		file.Close();
-		return new InferenceSession(model, SessionOpt); //Load the model
-	}
-	}
-}	
+            IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results;
+
+            try
+            {
+                results = session.Run(inputs, outputNames);
+            }
+            catch (OnnxRuntimeException e)
+            {
+                //This error usually means that the model is not compatible with the input, beacause of the input shape (size)
+                GD.Print("Error at inference: ", e);
+                return null;
+            }
+            //Can't convert IEnumerable<float> to Variant, so we have to convert it to an array or something
+            Godot.Collections.Dictionary<string, Godot.Collections.Array<float>> output = new Godot.Collections.Dictionary<string, Godot.Collections.Array<float>>();
+            DisposableNamedOnnxValue output1 = results.First();
+            DisposableNamedOnnxValue output2 = results.Last();
+            Godot.Collections.Array<float> output1Array = new Godot.Collections.Array<float>();
+            Godot.Collections.Array<float> output2Array = new Godot.Collections.Array<float>();
+
+            foreach (float f in output1.AsEnumerable<float>())
+            {
+                output1Array.Add(f);
+            }
+
+            foreach (float f in output2.AsEnumerable<float>())
+            {
+                output2Array.Add(f);
+            }
+
+            output.Add(output1.Name, output1Array);
+            output.Add(output2.Name, output2Array);
+
+            //Output is a dictionary of arrays, ex: { "output" : [0.1, 0.2, 0.3, 0.4, ...], "state_outs" : [0.5, ...]}
+            return output;
+        }
+        /// <include file='docs/ONNXInference.xml' path='docs/members[@name="ONNXInference"]/Load/*'/>
+        public InferenceSession LoadModel(string Path)
+        {
+            Godot.FileAccess file = FileAccess.Open(Path, Godot.FileAccess.ModeFlags.Read);
+            byte[] model = file.GetBuffer((int)file.GetLength());
+            file.Close();
+            return new InferenceSession(model, SessionOpt); //Load the model
+        }
+    }
+}

--- a/addons/godot_rl_agents/onnx/csharp/SessionConfigurator.cs
+++ b/addons/godot_rl_agents/onnx/csharp/SessionConfigurator.cs
@@ -1,106 +1,127 @@
 using Godot;
 using Microsoft.ML.OnnxRuntime;
 
-namespace GodotONNX{
-/// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/SessionConfigurator/*'/>
+namespace GodotONNX
+{
+    /// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/SessionConfigurator/*'/>
 
-	public static class SessionConfigurator {
+    public static class SessionConfigurator
+    {
+        public enum ComputeName
+        {
+            CUDA,
+            ROCm,
+            DirectML,
+            CoreML,
+            CPU
+        }
 
-		private static SessionOptions options = new SessionOptions();
-		
-/// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/GetSessionOptions/*'/>
-		public static SessionOptions GetSessionOptions() {
-			options = new SessionOptions();
-			options.LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING; 
-			// see warnings
-			SystemCheck();
-			return options;
-		}
-/// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/SystemCheck/*'/>
+        private static SessionOptions options = new SessionOptions();
 
-static public void SystemCheck()  
-	{
-		//Most code for this function is verbose only, the only reason it exists is to track
-		//implementation progress of the different compute APIs.
+        /// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/GetSessionOptions/*'/>
+        public static SessionOptions GetSessionOptions()
+        {
+            options.LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING;
+            // see warnings
+            SystemCheck();
+            return options;
+        }
 
-		//December 2022: CUDA is not working. 
+        /// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/SystemCheck/*'/>
+        static public void SystemCheck()
+        {
+            //Most code for this function is verbose only, the only reason it exists is to track
+            //implementation progress of the different compute APIs.
 
-		string OSName = OS.GetName(); //Get OS Name
-		int ComputeAPIID = ComputeCheck(); //Get Compute API
-		//TODO: Get CPU architecture
+            //December 2022: CUDA is not working. 
 
-		//Linux can use OpenVINO (C#) on x64 and ROCm on x86 (GDNative/C++)
-		//Windows can use OpenVINO (C#) on x64
-		//TODO: try TensorRT instead of CUDA
-		//TODO: Use OpenVINO for Intel Graphics
-		
-		string [] ComputeNames = {"CUDA", "DirectML/ROCm", "DirectML", "CoreML", "CPU"};
-		//match OS and Compute API
-		options.AppendExecutionProvider_CPU(0); // Always use CPU
-		GD.Print("OS: " + OSName, " | Compute API: " + ComputeNames[ComputeAPIID]);
+            string OSName = OS.GetName(); //Get OS Name
 
-		switch (OSName) 
-		{
-		case "Windows": //Can use CUDA, DirectML
-			if (ComputeAPIID == 0) 
-				{
-				//CUDA 
-				//options.AppendExecutionProvider_CUDA(0);
-				options.AppendExecutionProvider_DML(0);
-					}
-			else if (ComputeAPIID == 1) 
-				{ 
-				//DirectML
-				options.AppendExecutionProvider_DML(0);
-				}
-			break;
-		case "X11": //Can use CUDA, ROCm
-			if (ComputeAPIID == 0) 
-				{ 
-				//CUDA
-				//options.AppendExecutionProvider_CUDA(0);
-				}
-			if (ComputeAPIID == 1) 
-				{
-				//ROCm, only works on x86 
-				//Research indicates that this has to be compiled as a GDNative plugin
-				GD.Print("ROCm not supported yet, using CPU.");
-				options.AppendExecutionProvider_CPU(0);
-				}
-			
-			break;
-		case "OSX": //Can use CoreML
-			if (ComputeAPIID == 0) { //CoreML
-			//TODO: Needs testing
-				options.AppendExecutionProvider_CoreML(0); 
-				//CoreML on ARM64, out of the box, on x64 needs .tar file from GitHub
-				}
-			break;
-		default:
-			GD.Print("OS not Supported.");
-			break;
-		}
-	}
-/// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/ComputeCheck/*'/>
+            //ComputeName ComputeAPI = ComputeCheck(); //Get Compute API
+            //                                         //TODO: Get CPU architecture
+            
+            //Linux can use OpenVINO (C#) on x64 and ROCm on x86 (GDNative/C++)
+            //Windows can use OpenVINO (C#) on x64
+            //TODO: try TensorRT instead of CUDA
+            //TODO: Use OpenVINO for Intel Graphics
 
-	public static int ComputeCheck() 
-	{
-	string adapterName = Godot.RenderingServer.GetVideoAdapterName();
-	//string adapterVendor = Godot.RenderingServer.GetVideoAdapterVendor();
-	adapterName = adapterName.ToUpper(new System.Globalization.CultureInfo(""));
-	//TODO: GPU vendors for MacOS, what do they even use these days?
-	if (adapterName.Contains("INTEL")) {
-		//Return 2, should use DirectML only
-		return 2;}
-	if (adapterName.Contains("AMD")) {
-		//Return 1, should use DirectML, check later for ROCm
-		return 1;}
-	if (adapterName.Contains("NVIDIA")){
-		//Return 0, should use CUDA
-		return 0;}
-	
-	GD.Print("Graphics Card not recognized."); //Return -1, should use CPU
-	return -1;
-			}
-		}
-}	
+            // Temporarily using CPU on all platforms to avoid errors detected with DML
+            ComputeName ComputeAPI = ComputeName.CPU;
+
+            //match OS and Compute API
+            GD.Print($"OS: {OSName} Compute API: {ComputeAPI}");
+
+            options.AppendExecutionProvider_CPU(0);
+
+            /*
+            switch (OSName)
+            {
+                case "Windows": //Can use CUDA, DirectML
+                    if (ComputeAPI is ComputeName.CUDA)
+                    {
+                        //CUDA 
+                        //options.AppendExecutionProvider_CUDA(0);
+                        //options.AppendExecutionProvider_DML(0);
+                    }
+                    else if (ComputeAPI is ComputeName.DirectML)
+                    {
+                        //DirectML
+                        //options.AppendExecutionProvider_DML(0);
+                    }
+                    break;
+                case "X11": //Can use CUDA, ROCm
+                    if (ComputeAPI is ComputeName.CUDA)
+                    {
+                        //CUDA
+                        //options.AppendExecutionProvider_CUDA(0);
+                    }
+                    if (ComputeAPI is ComputeName.ROCm)
+                    {
+                        //ROCm, only works on x86 
+                        //Research indicates that this has to be compiled as a GDNative plugin
+                        //GD.Print("ROCm not supported yet, using CPU.");
+                        //options.AppendExecutionProvider_CPU(0);
+                    }
+                    break;
+                case "macOS": //Can use CoreML
+                    if (ComputeAPI is ComputeName.CoreML)
+                    { //CoreML
+                      //TODO: Needs testing
+                        //options.AppendExecutionProvider_CoreML(0);
+                        //CoreML on ARM64, out of the box, on x64 needs .tar file from GitHub
+                    }
+                    break;
+                default:
+                    GD.Print("OS not Supported.");
+                    break;
+            }
+            */
+        }
+        
+
+        /// <include file='docs/SessionConfigurator.xml' path='docs/members[@name="SessionConfigurator"]/ComputeCheck/*'/>
+        public static ComputeName ComputeCheck()
+        {
+            string adapterName = Godot.RenderingServer.GetVideoAdapterName();
+            //string adapterVendor = Godot.RenderingServer.GetVideoAdapterVendor();
+            adapterName = adapterName.ToUpper(new System.Globalization.CultureInfo(""));
+            //TODO: GPU vendors for MacOS, what do they even use these days?
+          
+            if (adapterName.Contains("INTEL"))
+            {
+                return ComputeName.DirectML;
+            }
+            if (adapterName.Contains("AMD") || adapterName.Contains("RADEON"))
+            {
+                return ComputeName.DirectML;
+            }
+            if (adapterName.Contains("NVIDIA"))
+            {
+                return ComputeName.CUDA;
+            }
+
+            GD.Print("Graphics Card not recognized."); //Should use CPU
+            return ComputeName.CPU;
+        }
+    }
+}

--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -43,17 +43,20 @@ func _initialize():
 	Engine.time_scale = _get_speedup() * 1.0
 	prints("physics ticks", Engine.physics_ticks_per_second, Engine.time_scale, _get_speedup(), speed_up)
 	
-
-	connected = connect_to_server()
-	if connected:
-		_set_heuristic("model")
-		_handshake()
-		_send_env_info()
-	elif onnx_model_path != "":
+	# Run inference if onnx model path is set, otherwise wait for server connection
+	var run_onnx_model_inference : bool = onnx_model_path != ""
+	if run_onnx_model_inference:
+		assert(FileAccess.file_exists(onnx_model_path), "Onnx Model Path set on Sync node does not exist: " + onnx_model_path)
 		onnx_model = ONNXModel.new(onnx_model_path, 1)
 		_set_heuristic("model")
-	else:
-		_set_heuristic("human")  
+	else:		
+		connected = connect_to_server()
+		if connected:
+			_set_heuristic("model")
+			_handshake()
+			_send_env_info()
+		else:
+			_set_heuristic("human")  
 		
 	_set_seed()
 	_set_action_repeat()


### PR DESCRIPTION
There are errors when using onnx files in Godot and when exporting projects using onnx files found so far on Windows and macOS such as: https://github.com/edbeeching/godot_rl_agents/issues/115

**This PR applies fixes for some of the errors:**

- Added `.vs/` to `.gitignore` so that temporary VS files are not commited.
- `Godot RL Agents.csproj` Removed `Microsoft.ML.OnnxRuntime.DirectML` and `Microsoft.ML.OnnxRuntime.GPU` packages as importing more than one package causes build errors when exporting application in Godot. Left only the main CPU package as only CPU is used in this update. Also updated `Godot.NET.Sdk` and `Microsoft.ML.OnnxRuntime` package to newer version.
- Changes to `Godot RL Agents.sln` were automatic by Visual Studio.
- `ONNXInference.cs` removed call to `SessionConfigurator.SystemCheck()` since it is already called in `SessionConfigurator.cs` `GetSessionOptions()`.
- `SessionConfigurator.cs` Replaced the array for compute names with enum to fix an array indexing error when running .onnx in Godot (showed on Windows and MacOS) and to make it easier to see the compute name in code. Temporarily set all devices to use CPU to fix inference errors encountered on Windows (RTX 3060, RX 570) and MacOS. Added `RADEON` to the logic for checking device name, so that my RX 570 can be detected. Changed logic in the now commented code section from "OSX" to "macOS" so that macOS can be detected properly if/when the logic is re-enabled.
- `sync.gd` if an onnx path is set, it will not wait for server connection (it took up to 30 seconds for the application to start on my system due to the delay). To train again, onnx path must be removed. Added an error message in case the set .onnx path does not exist or cannot be found by the system.

**Tests done:**
I have tried this plugin on some of the examples by taking the following steps:

1. Downloaded the latest examples from https://github.com/edbeeching/godot_rl_agents_examples
2. For `BallChase`, `FlyBy` and `JumperHard`: removed `addons` folder and `.csproj` file for each project, then copied the folder and the file from the updated plugin, and finally changed the name of each `.csproj` file from `Godot RL Agents.csproj` to the correct name for each project.
3. Added the relative path to the already existing .onnx file to the sync node, e.g.:
![image](https://github.com/edbeeching/godot_rl_agents_plugin/assets/61947090/2f149eda-a8d5-4536-afd0-8b222dd1e423)
4. Tried the game by pressing "Play".
5. (For some of the projects) exported the game to Windows, placed the `onnx` file in the same folder as the exported `exe` and started the application:
![image](https://github.com/edbeeching/godot_rl_agents_plugin/assets/61947090/3f6c13ca-3b20-48e7-96aa-dffdf93e3355)

For testing the error message, I tried entering a non-existing path to an .onnx file in the sync node:
![Godot_v4 0 3-stable_mono_win64_3vX4zucDhx](https://github.com/edbeeching/godot_rl_agents_plugin/assets/61947090/3cfe9562-39ed-4ba7-9755-24edbe47cfbc)

The tests ran with expected output using the plugin update from this PR.

**Known issues:**
As reported on Discord, exporting an application using onnx file from Godot on macOS causes issue due to `libonnxruntime.dylib` not being included in the exported .app file. Potentially related thread: https://github.com/godotengine/godot/issues/61313