### PR TITLE
Replace get_data() with get_image()

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
@@ -5,7 +5,7 @@ var camera_pixels = null
 @onready var camera_texture := $Control/TextureRect/CameraTexture as Sprite2D
 
 func get_camera_pixel_encoding():
-	return camera_texture.get_texture().get_data().data["data"].hex_encode()
+	return camera_texture.get_texture().get_image().data["data"].hex_encode()
 
 func get_camera_shape()-> Array:
 	return [$SubViewport.size[0], $SubViewport.size[1], 4]


### PR DESCRIPTION
While working on the examples I noticed that `get_data()` was renamed to `get_image()` in Godot 4. 

Godot 3: https://docs.godotengine.org/en/3.6/classes/class_texture.html
Godot 4: https://docs.godotengine.org/en/4.2/classes/class_texture2d.html