### PR TITLE
Fix inference when action names are not alphabetic

### DIFF
--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -179,7 +179,7 @@ func _get_dict_json_message():
 	return json_data
 
 func _send_dict_as_json_message(dict):
-	stream.put_string(JSON.stringify(dict))
+	stream.put_string(JSON.stringify(dict, "", false))
 
 func _send_env_info():
 	var json_dict = _get_dict_json_message()


### PR DESCRIPTION
This is a quick fix that should enable onnx inference to work for environments where the actions are not defined in an alphabetical order by name.

Only briefly tested, I have tried to quickly start training using `gdrl` and `play` in Editor.
Will test a bit more (export to onnx and run an onnx model) when I have some time to confirm. 

For an example action space that is not sorted:

With the applied fix, the action space as Printed from Python was:
```
action space {'acceleration': {'size': 1, 'action_type': 'continuous'}, '2': {'size': 1, 'action_type': 'continuous'}, '1': {'size': 1, 'action_type': 'continuous'}}
observation space {'obs': {'size': [12], 'space': 'box'}}
```
(same as the order written in AIController in gdscript)

Without the fix, the order of actions is changed before it reaches Python:
```
action space {'1': {'action_type': 'continuous', 'size': 1}, '2': {'action_type': 'continuous', 'size': 1}, 'acceleration': {'action_type': 'continuous', 'size': 1}}
observation space {'obs': {'size': [12], 'space': 'box'}}
```

More info on the issue itself is described in the linked issue. 