### PR TITLE
Fix channel count for RGBCameraSensor3D.gd

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
@@ -5,7 +5,7 @@ var camera_pixels = null
 @onready var camera_texture := $Control/TextureRect/CameraTexture as Sprite2D
 
 func get_camera_pixel_encoding():
-	return camera_texture.get_texture().get_image().data["data"].hex_encode()
+	return camera_texture.get_texture().get_image().get_data().hex_encode()
 
 func get_camera_shape()-> Array:
 	return [$SubViewport.size[0], $SubViewport.size[1], 3]

--- a/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
@@ -8,4 +8,4 @@ func get_camera_pixel_encoding():
 	return camera_texture.get_texture().get_data().data["data"].hex_encode()
 
 func get_camera_shape()-> Array:
-	return [$SubViewport.size[0], $SubViewport.size[1], 4]
+	return [$SubViewport.size[0], $SubViewport.size[1], 3]

--- a/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
@@ -8,4 +8,7 @@ func get_camera_pixel_encoding():
 	return camera_texture.get_texture().get_image().get_data().hex_encode()
 
 func get_camera_shape()-> Array:
-	return [$SubViewport.size[0], $SubViewport.size[1], 3]
+	if $SubViewport.transparent_bg:
+		return [$SubViewport.size[0], $SubViewport.size[1], 4]
+	else:
+		return [$SubViewport.size[0], $SubViewport.size[1], 3]


### PR DESCRIPTION
It seems that the image has 3 channels (no alpha) as checked in Godot 4.2, so this correction ensures that the correct shape of the data gets sent to Python.

Together with this PR: https://github.com/edbeeching/godot_rl_agents/pull/158
Should fix issue mentioned here: https://github.com/edbeeching/godot_rl_agents_examples/pull/14#issuecomment-1837311171