### PR TITLE
Update RGBCameraSensor3D.gd for CNN usage

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
@@ -8,7 +8,8 @@ func get_camera_pixel_encoding():
 	return camera_texture.get_texture().get_image().get_data().hex_encode()
 
 func get_camera_shape()-> Array:
+	assert($SubViewport.size.x >= 36 and $SubViewport.size.y >= 36, "SubViewport size must be 36x36 or larger.")
 	if $SubViewport.transparent_bg:
-		return [$SubViewport.size[0], $SubViewport.size[1], 4]
+		return [4, $SubViewport.size.y, $SubViewport.size.x]
 	else:
-		return [$SubViewport.size[0], $SubViewport.size[1], 3]
+		return [3, $SubViewport.size.y, $SubViewport.size.x]


### PR DESCRIPTION
* Added a warning when the image size is smaller than the needed size for SB3 CNN,
* Changed the shape of observations to the shape recommended by [sb3 docs custom environments](https://stable-baselines3.readthedocs.io/en/master/guide/custom_env.html#using-custom-environments):

> Although SB3 supports both channel-last and channel-first images as input, we recommend using the channel-first convention when possible. Under the hood, when a channel-last image is passed, SB3 uses a VecTransposeImage wrapper to re-order the channels.

> [!WARNING]
> Will break the virtual camera 3D example as it uses images smaller than 64x64, we can fix that by adjusting the subviewport size in the example (which the added assert will recommend).