### PR TITLE
Update RGBCameraSensor3D.gd for CNN usage

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
@@ -3,12 +3,19 @@ class_name RGBCameraSensor3D
 var camera_pixels = null
 
 @onready var camera_texture := $Control/TextureRect/CameraTexture as Sprite2D
+@onready var sub_viewport := $SubViewport as SubViewport
+
 
 func get_camera_pixel_encoding():
 	return camera_texture.get_texture().get_image().get_data().hex_encode()
 
-func get_camera_shape()-> Array:
-	if $SubViewport.transparent_bg:
-		return [$SubViewport.size[0], $SubViewport.size[1], 4]
+
+func get_camera_shape() -> Array:
+	assert(
+		sub_viewport.size.x >= 36 and sub_viewport.size.y >= 36,
+		"SubViewport size must be 36x36 or larger."
+	)
+	if sub_viewport.transparent_bg:
+		return [4, sub_viewport.size.y, sub_viewport.size.x]
 	else:
-		return [$SubViewport.size[0], $SubViewport.size[1], 3]
+		return [3, sub_viewport.size.y, sub_viewport.size.x]


### PR DESCRIPTION
* Added a warning when the image size is smaller than the needed size for SB3 CNN,
* Changed the shape of observations to the shape recommended by [sb3 docs custom environments](https://stable-baselines3.readthedocs.io/en/master/guide/custom_env.html#using-custom-environments):

> Although SB3 supports both channel-last and channel-first images as input, we recommend using the channel-first convention when possible. Under the hood, when a channel-last image is passed, SB3 uses a VecTransposeImage wrapper to re-order the channels.

> [!WARNING]
> Will break the virtual camera 3D example as it uses images smaller than 36x36, we can fix that by adjusting the subviewport size in the example (which the added assert will recommend).