### PR TITLE
Fix class_sensor type mismatch error in RaycastSensor3D.gd

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_3d/RaycastSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RaycastSensor3D.gd
@@ -148,12 +148,12 @@ func calculate_raycasts() -> Array:
 
 		result.append(distance)
 		if class_sensor:
-			var hit_class = 0 
+			var hit_class: float = 0 
 			if ray.get_collider():
 				var hit_collision_layer = ray.get_collider().collision_layer
 				hit_collision_layer = hit_collision_layer & collision_mask
 				hit_class = (hit_collision_layer & boolean_class_mask) > 0
-			result.append(hit_class)
+			result.append(float(hit_class))
 		ray.set_enabled(false)
 	return result
 


### PR DESCRIPTION
When using the class sensor option and storing the observations in a float array, an error occurs:

> E 0:00:17:0513   RobotAIController.gd:37 @ get_raycast_sensor_obs(): Attempted to append_array a variable of type 'bool' into a TypedArray of type 'float'.
  <C++ Error>    Method/function failed. Returning: false
  <C++ Source>   core/variant/container_type_validate.h:97 @ validate()
  <Stack Trace>  RobotAIController.gd:37 @ get_raycast_sensor_obs()
                 RobotAIController.gd:13 @ get_obs()
                 sync.gd:315 @ _get_obs_from_agents()
                 sync.gd:100 @ _physics_process()

Converting the type of the class sensor detection to float resolves this issue.