### PR TITLE
Refactor RaycastSensor2D.gd

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_2d/RaycastSensor2D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_2d/RaycastSensor2D.gd
@@ -29,9 +29,10 @@ class_name RaycastSensor2D
 	set(value):
 		n_rays = value
 		_update()
-	
-@export_range(5,2000,5.0) var ray_length := 200:
-	get: return ray_length
+
+@export_range(5, 3000, 5.0) var ray_length := 200:
+	get:
+		return ray_length
 	set(value):
 		ray_length = value
 		_update()
@@ -93,24 +94,18 @@ func _spawn_nodes():
 		_angles.append(start + i * step)
 
 
-func _physics_process(delta: float) -> void:
-	if self._active:
-		self._obs = calculate_raycasts()
-
-
 func get_observation() -> Array:
-	if len(self._obs) == 0:
-		print("obs was null, forcing raycast update")
-		return self.calculate_raycasts()
-	return self._obs
+	return self.calculate_raycasts()
 
 
 func calculate_raycasts() -> Array:
 	var result = []
 	for ray in rays:
+		ray.enabled = true
 		ray.force_raycast_update()
 		var distance = _get_raycast_distance(ray)
 		result.append(distance)
+		ray.enabled = false
 	return result
 
 

--- a/addons/godot_rl_agents/sensors/sensors_2d/RaycastSensor2D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_2d/RaycastSensor2D.gd
@@ -29,10 +29,9 @@ class_name RaycastSensor2D
 	set(value):
 		n_rays = value
 		_update()
-
-@export_range(5, 200, 5.0) var ray_length := 200:
-	get:
-		return ray_length
+	
+@export_range(5,2000,5.0) var ray_length := 200:
+	get: return ray_length
 	set(value):
 		ray_length = value
 		_update()

--- a/addons/godot_rl_agents/sensors/sensors_2d/RaycastSensor2D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_2d/RaycastSensor2D.gd
@@ -84,7 +84,7 @@ func _spawn_nodes():
 			Vector2(ray_length * cos(deg_to_rad(angle)), ray_length * sin(deg_to_rad(angle)))
 		)
 		ray.set_name("node_" + str(i))
-		ray.enabled = true
+		ray.enabled = false
 		ray.collide_with_areas = collide_with_areas
 		ray.collide_with_bodies = collide_with_bodies
 		ray.collision_mask = collision_mask


### PR DESCRIPTION
Previous max ray length of 200 in inspector was not sufficient for a test env, e.g.:

![raycast_max_length_200](https://github.com/edbeeching/godot_rl_agents_plugin/assets/61947090/5a120ade-0827-42d6-8d94-34f57d349b9f)

This increases the limit to 3000. 

Also, it refactors the sensor to be more similar to the 3D variant and reformats it with gdformat for more consistency with other recent plugin branches. It disables the raycasts between `get_observation()` requests, which will increase FPS depending on action repeat.