### PR TITLE
Adds downscaling to RGBCameraSensor3D.gd

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
@@ -2,20 +2,64 @@ extends Node3D
 class_name RGBCameraSensor3D
 var camera_pixels = null
 
-@onready var camera_texture := $Control/TextureRect/CameraTexture as Sprite2D
+@onready var camera_texture := $Control/CameraTexture as Sprite2D
+@onready var processed_texture := $Control/ProcessedTexture as Sprite2D
 @onready var sub_viewport := $SubViewport as SubViewport
+@onready var displayed_image: ImageTexture
+
+@export var render_image_resolution := Vector2(36, 36)
+## Display size does not affect rendered or sent image resolution.
+## Scale is relative to either render image or downscale image resolution
+## depending on which mode is set.
+@export var displayed_image_scale_factor := Vector2(8, 8)
+
+@export_group("Downscale image options")
+## Enable to downscale the rendered image before sending the obs.
+@export var downscale_image: bool = false
+## If downscale_image is true, will display the downscaled imasge instead of rendered image.
+@export var display_downscaled_image: bool = true
+## This is the resolution of the image that will be sent after downscaling
+@export var resized_image_resolution := Vector2(36, 36)
+
+
+func _ready():
+	sub_viewport.size = render_image_resolution
+	camera_texture.scale = displayed_image_scale_factor
+
+	if downscale_image:
+		camera_texture.visible = false
+
+		if display_downscaled_image:
+			processed_texture.scale = displayed_image_scale_factor
+	else:
+		processed_texture.visible = false
 
 
 func get_camera_pixel_encoding():
-	return camera_texture.get_texture().get_image().get_data().hex_encode()
+	var image := camera_texture.get_texture().get_image() as Image
+
+	if downscale_image:
+		image.resize(
+			resized_image_resolution.x, resized_image_resolution.y, Image.INTERPOLATE_NEAREST
+		)
+		if display_downscaled_image:
+			if not processed_texture.texture:
+				displayed_image = ImageTexture.create_from_image(image)
+				processed_texture.texture = displayed_image
+			else:
+				displayed_image.update(image)
+
+	return image.get_data().hex_encode()
 
 
 func get_camera_shape() -> Array:
+	var size = resized_image_resolution if downscale_image else render_image_resolution
+
 	assert(
-		sub_viewport.size.x >= 36 and sub_viewport.size.y >= 36,
-		"SubViewport size must be 36x36 or larger."
+		size.x >= 36 and size.y >= 36,
+		"Camera sensor sent image resolution must be 36x36 or larger."
 	)
 	if sub_viewport.transparent_bg:
-		return [4, sub_viewport.size.y, sub_viewport.size.x]
+		return [4, size.y, size.x]
 	else:
-		return [3, sub_viewport.size.y, sub_viewport.size.x]
+		return [3, size.y, size.x]

--- a/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.tscn
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.tscn
@@ -2,20 +2,20 @@
 
 [ext_resource type="Script" path="res://addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd" id="1"]
 
-[sub_resource type="ViewportTexture" id="1"]
+[sub_resource type="ViewportTexture" id="ViewportTexture_y72s3"]
 viewport_path = NodePath("SubViewport")
 
 [node name="RGBCameraSensor3D" type="Node3D"]
 script = ExtResource("1")
 
-[node name="RemoteTransform3D" type="RemoteTransform3D" parent="."]
-remote_path = NodePath("../SubViewport/Camera3D")
+[node name="RemoteTransform" type="RemoteTransform3D" parent="."]
+remote_path = NodePath("../SubViewport/Camera")
 
 [node name="SubViewport" type="SubViewport" parent="."]
-size = Vector2i(32, 32)
+size = Vector2i(36, 36)
 render_target_update_mode = 3
 
-[node name="Camera3D" type="Camera3D" parent="SubViewport"]
+[node name="Camera" type="Camera3D" parent="SubViewport"]
 near = 0.5
 
 [node name="Control" type="Control" parent="."]
@@ -25,17 +25,11 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+metadata/_edit_use_anchors_ = true
 
-[node name="TextureRect" type="ColorRect" parent="Control"]
-layout_mode = 0
-offset_left = 1096.0
-offset_top = 534.0
-offset_right = 1114.0
-offset_bottom = 552.0
-scale = Vector2(10, 10)
-color = Color(0.00784314, 0.00784314, 0.00784314, 1)
+[node name="CameraTexture" type="Sprite2D" parent="Control"]
+texture = SubResource("ViewportTexture_y72s3")
+centered = false
 
-[node name="CameraTexture" type="Sprite2D" parent="Control/TextureRect"]
-texture = SubResource("1")
-offset = Vector2(9, 9)
-flip_v = true
+[node name="ProcessedTexture" type="Sprite2D" parent="Control"]
+centered = false


### PR DESCRIPTION
Adds the ability to resize the image before sending it to the Python server.

![image](https://github.com/edbeeching/godot_rl_agents_plugin/assets/61947090/75866159-1a91-48fd-a34e-725cf6ecd961)

Briefly tried on the VirtualCamera example. 

Setting a high image render resolution will have a performance impact, and using some downscaling interpolation can have an impact (although I did not measure the impact), so it is currently using just nearest-neighbor.