### PR TITLE
Fix scene changing support

### DIFF
--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -59,7 +59,7 @@ var _obs_space_training: Array[Dictionary] = []
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	await get_tree().root.ready
+	await get_parent().ready
 	get_tree().set_pause(true)
 	_initialize()
 	await get_tree().create_timer(1.0).timeout


### PR DESCRIPTION
Awaiting for the parent node to send the `ready` signal should fix an old issue with scene changing not working when using sync node (because if the root node has already loaded, it won't send the ready signal again, so the sync node may wait forever). 

This does require the "standard" placement of the sync node such that the parent node is the main training/inference scene node.

Big thanks to https://github.com/JayRothenberger for testing this solution.