### PR TITLE
fix: fixing order when setting action on agent_demo_record

### DIFF
--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -70,7 +70,7 @@ func _ready():
 func _initialize():
 	_get_agents()
 	args = _get_args()
-	Engine.physics_ticks_per_second = _get_speedup() * 60  # Replace with function body.
+	Engine.physics_ticks_per_second = _get_speedup() * 60 # Replace with function body.
 	Engine.time_scale = _get_speedup() * 1.0
 	prints(
 		"physics ticks",
@@ -263,8 +263,8 @@ func _demo_record_process():
 	current_demo_trajectory[0].append(obs_dict.obs)
 
 	# Get the action applied for the current obs from the agent
-	agent_demo_record.set_action()
 	var acts = agent_demo_record.get_action()
+	agent_demo_record.set_action(acts)
 
 	var terminal = agent_demo_record.get_done()
 	# Record actions only for non-terminal states
@@ -293,22 +293,22 @@ func _extract_action_dict(action_array: Array, action_space: Dictionary, action_
 		var size = action_space[key]["size"]
 		var action_type = action_space[key]["action_type"]
 		if action_type == "discrete":
-			var largest_logit: float  # Value of the largest logit for this action in the actions array
-			var largest_logit_idx: int  # Index of the largest logit for this action in the actions array
+			var largest_logit: float # Value of the largest logit for this action in the actions array
+			var largest_logit_idx: int # Index of the largest logit for this action in the actions array
 			for logit_idx in range(0, size):
 				var logit_value = action_array[index + logit_idx]
 				if logit_value > largest_logit:
 					largest_logit = logit_value
 					largest_logit_idx = logit_idx
-			result[key] = largest_logit_idx  # Index of the largest logit is the discrete action value
+			result[key] = largest_logit_idx # Index of the largest logit is the discrete action value
 			index += size
 		elif action_type == "continuous":
 			# For continous actions, we only take the action mean values
 			result[key] = clamp_array(action_array.slice(index, index + size), -1.0, 1.0)
 			if action_means_only:
-				index += size  # model only outputs action means, so we move index by size
+				index += size # model only outputs action means, so we move index by size
 			else:
-				index += size * 2  # model outputs logstd after action mean, we skip the logstd part
+				index += size * 2 # model outputs logstd after action mean, we skip the logstd part
 
 		else:
 			assert(
@@ -426,7 +426,7 @@ func connect_to_server():
 	var ip = "127.0.0.1"
 	var port = _get_port()
 	var connect = stream.connect_to_host(ip, port)
-	stream.set_no_delay(true)  # TODO check if this improves performance or not
+	stream.set_no_delay(true) # TODO check if this improves performance or not
 	stream.poll()
 	# Fetch the status until it is either connected (2) or failed to connect (3)
 	while stream.get_status() < 2:


### PR DESCRIPTION
I found a small bug where the order of `get` and `set` were inverted. 

It may be a bit hard to see it because my linter messed around with the spacings. I'll add a comment to make it more visible.