### PR TITLE
Adds camera sensor 2D

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_2d/RGBCameraSensor2D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_2d/RGBCameraSensor2D.gd
@@ -1,0 +1,77 @@
+extends Node2D
+class_name RGBCameraSensor2D
+var camera_pixels = null
+
+@export var camera_zoom_factor := Vector2(0.1, 0.1)
+@onready var camera := $SubViewport/Camera
+@onready var preview_window := $Control
+@onready var camera_texture := $Control/CameraTexture as Sprite2D
+@onready var processed_texture := $Control/ProcessedTexture as Sprite2D
+@onready var sub_viewport := $SubViewport as SubViewport
+@onready var displayed_image: ImageTexture
+
+@export var render_image_resolution := Vector2(36, 36)
+## Display size does not affect rendered or sent image resolution.
+## Scale is relative to either render image or downscale image resolution
+## depending on which mode is set.
+@export var displayed_image_scale_factor := Vector2(8, 8)
+
+@export_group("Downscale image options")
+## Enable to downscale the rendered image before sending the obs.
+@export var downscale_image: bool = false
+## If downscale_image is true, will display the downscaled image instead of rendered image.
+@export var display_downscaled_image: bool = true
+## This is the resolution of the image that will be sent after downscaling
+@export var resized_image_resolution := Vector2(36, 36)
+
+
+func _ready():
+	DisplayServer.register_additional_output(self)
+
+	camera.zoom = camera_zoom_factor
+
+	var preview_size: Vector2
+
+	sub_viewport.world_2d = get_tree().get_root().get_world_2d()
+	sub_viewport.size = render_image_resolution
+	camera_texture.scale = displayed_image_scale_factor
+
+	if downscale_image and display_downscaled_image:
+		camera_texture.visible = false
+		processed_texture.scale = displayed_image_scale_factor
+		preview_size = displayed_image_scale_factor * resized_image_resolution
+	else:
+		processed_texture.visible = false
+		preview_size = displayed_image_scale_factor * render_image_resolution
+
+	preview_window.size = preview_size
+
+
+func get_camera_pixel_encoding():
+	var image := camera_texture.get_texture().get_image() as Image
+
+	if downscale_image:
+		image.resize(
+			resized_image_resolution.x, resized_image_resolution.y, Image.INTERPOLATE_NEAREST
+		)
+		if display_downscaled_image:
+			if not processed_texture.texture:
+				displayed_image = ImageTexture.create_from_image(image)
+				processed_texture.texture = displayed_image
+			else:
+				displayed_image.update(image)
+
+	return image.get_data().hex_encode()
+
+
+func get_camera_shape() -> Array:
+	var size = resized_image_resolution if downscale_image else render_image_resolution
+
+	assert(
+		size.x >= 36 and size.y >= 36,
+		"Camera sensor sent image resolution must be 36x36 or larger."
+	)
+	if sub_viewport.transparent_bg:
+		return [4, size.y, size.x]
+	else:
+		return [3, size.y, size.x]

--- a/addons/godot_rl_agents/sensors/sensors_2d/RGBCameraSensor2D.tscn
+++ b/addons/godot_rl_agents/sensors/sensors_2d/RGBCameraSensor2D.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=3 format=3 uid="uid://bav1cl8uwc45c"]
+
+[ext_resource type="Script" path="res://addons/godot_rl_agents/sensors/sensors_2d/RGBCameraSensor2D.gd" id="1_txpo2"]
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_jks1s"]
+viewport_path = NodePath("SubViewport")
+
+[node name="RGBCameraSensor2D" type="Node2D"]
+script = ExtResource("1_txpo2")
+displayed_image_scale_factor = Vector2(3, 3)
+
+[node name="RemoteTransform" type="RemoteTransform2D" parent="."]
+remote_path = NodePath("../SubViewport/Camera")
+
+[node name="SubViewport" type="SubViewport" parent="."]
+canvas_item_default_texture_filter = 0
+size = Vector2i(36, 36)
+render_target_update_mode = 4
+
+[node name="Camera" type="Camera2D" parent="SubViewport"]
+position_smoothing_speed = 2.0
+
+[node name="Control" type="Window" parent="."]
+canvas_item_default_texture_filter = 0
+title = "CameraSensor"
+position = Vector2i(20, 40)
+size = Vector2i(64, 64)
+theme_override_font_sizes/title_font_size = 12
+metadata/_edit_use_anchors_ = true
+
+[node name="CameraTexture" type="Sprite2D" parent="Control"]
+texture = SubResource("ViewportTexture_jks1s")
+centered = false
+
+[node name="ProcessedTexture" type="Sprite2D" parent="Control"]
+centered = false


### PR DESCRIPTION
Adds the 2D variant of the current 3D camera sensor. The main goal of the PR is to bring 2D support to a similar state as the 3D sensor and make them similar to use. This PR does not deal with e.g. onnx inference.

Test env: https://github.com/edbeeching/godot_rl_agents_examples/pull/42

## Usage:
1) Just as with the RGBCameraSensor3D, search for `RGBCameraSensor2D` in Godot filesystem and attach it to the player or AIController:
![image](https://github.com/user-attachments/assets/46d34a14-9b06-4ae4-9db7-5e16f7dd9351)
2) Adjust the observation space and for the camera sensor, mark it with _2d so that the Python side will recognize it as image obs. Here is the code from the example env that also has commented parts for vector obs, in case combining them is needed (I didn't test mixing vector + image obs specifically on this env, but tested previously with the 3D version so it should work):
```gdscript
func get_obs_space():
	#var vector_obs_shape = [get_vector_obs().size()]
	var image_obs_shape = camera_sensor.get_camera_shape()
	return {
		#"obs": {"size": vector_obs_shape, "space": "box"},
		"camera_2d": {"size": image_obs_shape, "space": "box"},
	}


func get_image_obs() -> String:
	return camera_sensor.get_camera_pixel_encoding()


# Uncomment if using some vector obs
# (make sure to also uncomment the sections in get_obs_space/get_obs)
#func get_vector_obs() -> Array:
	#var vector_obs: Array
	#return vector_obs


func get_obs():
	return {
		#"obs": get_vector_obs(),
		"camera_2d": get_image_obs(),
	}
```


You can train it as usual, you can test Cnn or Mlp easily by adjusting the SB3 example script as below:
1) Change:
```python
env = StableBaselinesGodotEnv(
    env_path=args.env_path, show_window=args.viz, seed=args.seed, n_parallel=args.n_parallel, speedup=args.speedup
)
```
to 
```python
env = SBGSingleObsEnv(
    obs_key="camera_2d", env_path=args.env_path, show_window=args.viz, seed=args.seed, n_parallel=args.n_parallel, speedup=args.speedup
)
```
2) Change:
```python
    model: PPO = PPO(
        "MultiInputPolicy",
```
to use either `MlpPolicy` or `CnnPolicy`. 
This works with a single obs space, and for mixing the `MultiInputPolicy` is required, which will use CNN.

## Other notes:

There are small modifications to make this work with 2D in a similar way as the 3D sensor.

![image](https://github.com/user-attachments/assets/2977634d-70af-435e-924a-fbb070163219)

1) SubViewport is manually assigned in code (in `RGBCameraSensor2D`) to use the shared World2D space as the root.
2) `Control` is changed to a window. That way the camera display doesn't render on the same viewport that is being captured. Also, as a nice side-effect, we can move the window for each AIController that uses the sensor. I'm thinking of adding this to the 3D sensor too.

https://github.com/user-attachments/assets/0ff7ad50-8011-435f-b307-a90e6db03660

3) On Windows (possibly other OS too), if you start training with a minimized window, or you minimize it, training won't work well as the images aren't getting updated. I tested this by saving the images at intervals, and the images didn't change as time passes if the game started minimized (behavior might depend on Windows settings too, but at least on mine it doesn't work minimized). This was fixed by adding this line to the camera sensor code (may need to be added to the 3D sensor too, after testing if the same behavior applies): `DisplayServer.register_additional_output(self)`.


TODO:
- [x] Upload mini test env
- [x] Update description