### PR TITLE
onnx inference: support whole observation dictionary as input to the onnx model

### DIFF
--- a/addons/godot_rl_agents/onnx/wrapper/ONNX_wrapper.gd
+++ b/addons/godot_rl_agents/onnx/wrapper/ONNX_wrapper.gd
@@ -21,7 +21,7 @@ func _init(model_path, batch_size):
 	action_output_size = inferencer.Initialize(model_path, batch_size)
 
 # This function is the one that will be called from the game,
-# requires the observations as an Dictinoary and the state_ins as an int
+# requires the observations as an Dictionary and the state_ins as an int
 # returns a Dictionary containing the action the model takes.
 func run_inference(obs: Dictionary, state_ins: int) -> Dictionary:
 	if inferencer == null:

--- a/addons/godot_rl_agents/onnx/wrapper/ONNX_wrapper.gd
+++ b/addons/godot_rl_agents/onnx/wrapper/ONNX_wrapper.gd
@@ -22,7 +22,7 @@ func _init(model_path, batch_size):
 
 # This function is the one that will be called from the game,
 # requires the observations as an Dictinoary and the state_ins as an int
-# returns a Dictinoary containing the action the model takes.
+# returns a Dictionary containing the action the model takes.
 func run_inference(obs: Dictionary, state_ins: int) -> Dictionary:
 	if inferencer == null:
 		printerr("Inferencer not initialized")

--- a/addons/godot_rl_agents/onnx/wrapper/ONNX_wrapper.gd
+++ b/addons/godot_rl_agents/onnx/wrapper/ONNX_wrapper.gd
@@ -21,9 +21,9 @@ func _init(model_path, batch_size):
 	action_output_size = inferencer.Initialize(model_path, batch_size)
 
 # This function is the one that will be called from the game,
-# requires the observation as an array and the state_ins as an int
-# returns an Array containing the action the model takes.
-func run_inference(obs: Array, state_ins: int) -> Dictionary:
+# requires the observations as an Dictinoary and the state_ins as an int
+# returns a Dictinoary containing the action the model takes.
+func run_inference(obs: Dictionary, state_ins: int) -> Dictionary:
 	if inferencer == null:
 		printerr("Inferencer not initialized")
 		return {}

--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -230,7 +230,9 @@ func _inference_process():
 
 		for agent_id in range(0, agents_inference.size()):
 			var model: ONNXModel = agents_inference[agent_id].onnx_model
-			var action = model.run_inference(obs[agent_id]["obs"], 1.0)
+			var action = model.run_inference(
+				obs[agent_id], 1.0
+			)
 			var action_dict = _extract_action_dict(
 				action["output"], _action_space_inference[agent_id], model.action_means_only
 			)


### PR DESCRIPTION
The current implementation of the onnx inference only takes into account the "obs" key from each agent's observation dictionary. The changes in this PR allow each aspect of the observation to be used as input to the onnx model.

For this change, the 'obs' parameter of ONNXInference.RunInference is changed from Godot Array to Godot Dictionary. This actually aligns the implementation with the current documentation in 'docs/ONNXInference.xml/Run' that states: "\<param name="obs"\>Dictionary containing all observations.\</param\>".

This PR should be non-breaking and is related to this PR (but it is not depending on it to work): [edbeeching/godot_rl_agents/pull/231]

Please let me know if any changes or information are necessary to get this merged.