### PR TITLE
Fix largest logit selection in sync.gd

### DIFF
--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -295,8 +295,8 @@ func _extract_action_dict(action_array: Array, action_space: Dictionary, action_
 		var size = action_space[key]["size"]
 		var action_type = action_space[key]["action_type"]
 		if action_type == "discrete":
-			var largest_logit: float  # Value of the largest logit for this action in the actions array
-			var largest_logit_idx: int  # Index of the largest logit for this action in the actions array
+			var largest_logit: float = -INF  # Value of the largest logit for this action in the actions array
+			var largest_logit_idx: int = 0  # Index of the largest logit for this action in the actions array
 			for logit_idx in range(0, size):
 				var logit_value = action_array[index + logit_idx]
 				if logit_value > largest_logit:


### PR DESCRIPTION
Should select the largest logit correctly when logits are below 0.

Not tested yet.