### PR TITLE
Allow smaller reward scale for ApproachNodeReward

### DIFF
--- a/addons/godot_rl_agents/rewards/ApproachNodeReward3D.gd
+++ b/addons/godot_rl_agents/rewards/ApproachNodeReward3D.gd
@@ -10,7 +10,7 @@ class_name ApproachNodeReward3D
 
 ## Scales the reward, 1.0 means the reward is equal to 
 ## how much closer the agent is than the previous best.
-@export var reward_scale: float = 1.0
+@export_range(0.0, 1.0, 0.0001, "or_greater") var reward_scale: float = 1.0
 
 var _best_distance
 


### PR DESCRIPTION
Makes it possible to write smaller values for the reward scale in the inspector, which is sometimes needed if the reward should be kept small, especially in 2D environments where the distance to goal might be large. 

![image](https://github.com/user-attachments/assets/99495ce9-670e-4a2b-bfbf-769a378aa33e)
