### PR TITLE
prevent _ready() hang when using dynamic agent setup

### DIFF
--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -60,11 +60,11 @@ var _obs_space_training: Array[Dictionary] = []
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	await get_parent().ready
-	get_tree().set_pause(true)
-	_initialize()
-	await get_tree().create_timer(1.0).timeout
-	get_tree().set_pause(false)
+	call_deferred("_try_initialize")
+
+func _try_initialize():
+	if not initialized:
+		_initialize()
 
 
 func _initialize():


### PR DESCRIPTION
Fixes: GH-55

Avoids waiting on already-fired `ready` signals by deferring _initialize() using `call_deferred()`. This ensures all dynamically added nodes and dependencies have completed their own _ready() methods before initialization.