### PR TITLE
Fix type for camera sensor size

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_2d/RGBCameraSensor2D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_2d/RGBCameraSensor2D.gd
@@ -10,11 +10,11 @@ var camera_pixels = null
 @onready var sub_viewport := $SubViewport as SubViewport
 @onready var displayed_image: ImageTexture
 
-@export var render_image_resolution := Vector2(36, 36)
+@export var render_image_resolution := Vector2i(36, 36)
 ## Display size does not affect rendered or sent image resolution.
 ## Scale is relative to either render image or downscale image resolution
 ## depending on which mode is set.
-@export var displayed_image_scale_factor := Vector2(8, 8)
+@export var displayed_image_scale_factor := Vector2i(8, 8)
 
 @export_group("Downscale image options")
 ## Enable to downscale the rendered image before sending the obs.

--- a/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RGBCameraSensor3D.gd
@@ -7,11 +7,11 @@ var camera_pixels = null
 @onready var sub_viewport := $SubViewport as SubViewport
 @onready var displayed_image: ImageTexture
 
-@export var render_image_resolution := Vector2(36, 36)
+@export var render_image_resolution := Vector2i(36, 36)
 ## Display size does not affect rendered or sent image resolution.
 ## Scale is relative to either render image or downscale image resolution
 ## depending on which mode is set.
-@export var displayed_image_scale_factor := Vector2(8, 8)
+@export var displayed_image_scale_factor := Vector2i(8, 8)
 
 @export_group("Downscale image options")
 ## Enable to downscale the rendered image before sending the obs.


### PR DESCRIPTION
Recently I got an error due to size being sent as float (Godot 4.5.beta2, recent SB3 ver).

`AssertionError: Expected all shape elements to be an integer, actual type: (<class 'int'>, <class 'float'>, <class 'float'>)`

This is a briefly tested (with sensor 3d only) simple fix.

