### PR TITLE
Fix for GridSensor3D Warning: Cannot pass 1 as Enum "BaseMaterial3D.Transparency"

### DIFF
--- a/addons/godot_rl_agents/sensors/sensors_3d/GridSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/GridSensor3D.gd
@@ -97,13 +97,13 @@ func _make_materials() -> void:
 		return
 
 	_standard_box_material = StandardMaterial3D.new()
-	_standard_box_material.set_transparency(1)  # ALPHA
+	_standard_box_material.set_transparency(StandardMaterial3D.Transparency.TRANSPARENCY_ALPHA)  # ALPHA
 	_standard_box_material.albedo_color = Color(
 		100.0 / 255.0, 100.0 / 255.0, 100.0 / 255.0, 100.0 / 255.0
 	)
 
 	_highlighted_box_material = StandardMaterial3D.new()
-	_highlighted_box_material.set_transparency(1)  # ALPHA
+	_highlighted_box_material.set_transparency(StandardMaterial3D.Transparency.TRANSPARENCY_ALPHA)  # ALPHA
 	_highlighted_box_material.albedo_color = Color(
 		255.0 / 255.0, 100.0 / 255.0, 100.0 / 255.0, 100.0 / 255.0
 	)


### PR DESCRIPTION
Fixes the following warning by replacing the integer with the enum:

```
W 0:00:00:559   GDScript::reload: Cannot pass 1 as Enum "BaseMaterial3D.Transparency": no enum member has matching value.
  <GDScript Error>INT_AS_ENUM_WITHOUT_MATCH
  <GDScript Source>GridSensorStaticOnly3D.gd:100 @ GDScript::reload()
```

Checked with Godot 4.6.1. 

Note: Filename in warning log doesn't match as I got the warning on a locally modified sensor with a different filename, but otherwise the fix matches.