### PR TITLE
Improved RayCastSensor2D/3D debugging and fixed observations when done is set to true

### DIFF
--- a/addons/godot_rl_agents/controller/ai_controller_2d.gd
+++ b/addons/godot_rl_agents/controller/ai_controller_2d.gd
@@ -33,7 +33,15 @@ enum ControlModes {
 var onnx_model: ONNXModel
 
 var heuristic := "human"
-var done := false
+var obs_done : Dictionary
+var done := false:
+	get:
+		return done
+	set(value):
+		done = value
+		if done:
+			# store the observation when a terminal state was observed (done was set to true)
+			obs_done = get_obs()
 var reward := 0.0
 var n_steps := 0
 var needs_reset := false
@@ -53,6 +61,12 @@ func init(player: Node2D):
 func get_obs() -> Dictionary:
 	assert(false, "the get_obs method is not implemented when extending from ai_controller")
 	return {"obs": []}
+
+
+func get_obs_done() -> Dictionary:
+	var obs = obs_done
+	obs_done = {} # empty it for checking purposes
+	return obs
 
 
 func get_reward() -> float:

--- a/addons/godot_rl_agents/controller/ai_controller_2d.gd
+++ b/addons/godot_rl_agents/controller/ai_controller_2d.gd
@@ -34,6 +34,7 @@ var onnx_model: ONNXModel
 
 var heuristic := "human"
 var obs_done : Dictionary
+var keep_action := false
 var done := false:
 	get:
 		return done
@@ -148,3 +149,11 @@ func set_done_false():
 
 func zero_reward():
 	reward = 0.0
+
+
+func get_keep_action():
+	return keep_action
+
+
+func set_keep_action(v):
+	keep_action = v

--- a/addons/godot_rl_agents/controller/ai_controller_2d.gd
+++ b/addons/godot_rl_agents/controller/ai_controller_2d.gd
@@ -34,7 +34,6 @@ var onnx_model: ONNXModel
 
 var heuristic := "human"
 var obs_done : Dictionary
-var keep_action := false
 var done := false:
 	get:
 		return done
@@ -149,11 +148,3 @@ func set_done_false():
 
 func zero_reward():
 	reward = 0.0
-
-
-func get_keep_action():
-	return keep_action
-
-
-func set_keep_action(v):
-	keep_action = v

--- a/addons/godot_rl_agents/controller/ai_controller_3d.gd
+++ b/addons/godot_rl_agents/controller/ai_controller_3d.gd
@@ -33,7 +33,15 @@ enum ControlModes {
 var onnx_model: ONNXModel
 
 var heuristic := "human"
-var done := false
+var obs_done : Dictionary
+var done := false:
+	get:
+		return done
+	set(value):
+		done = value
+		if done:
+			# store the observation when a terminal state was observed (done was set to true)
+			obs_done = get_obs()
 var reward := 0.0
 var n_steps := 0
 var needs_reset := false
@@ -53,6 +61,12 @@ func init(player: Node3D):
 func get_obs() -> Dictionary:
 	assert(false, "the get_obs method is not implemented when extending from ai_controller")
 	return {"obs": []}
+
+
+func get_obs_done() -> Dictionary:
+	var obs = obs_done
+	obs_done = {} # empty it for checking purposes
+	return obs
 
 
 func get_reward() -> float:

--- a/addons/godot_rl_agents/controller/ai_controller_3d.gd
+++ b/addons/godot_rl_agents/controller/ai_controller_3d.gd
@@ -34,6 +34,7 @@ var onnx_model: ONNXModel
 
 var heuristic := "human"
 var obs_done : Dictionary
+var keep_action := false
 var done := false:
 	get:
 		return done
@@ -148,3 +149,11 @@ func set_done_false():
 
 func zero_reward():
 	reward = 0.0
+
+
+func get_keep_action():
+	return keep_action
+
+
+func set_keep_action(v):
+	keep_action = v

--- a/addons/godot_rl_agents/controller/ai_controller_3d.gd
+++ b/addons/godot_rl_agents/controller/ai_controller_3d.gd
@@ -34,7 +34,6 @@ var onnx_model: ONNXModel
 
 var heuristic := "human"
 var obs_done : Dictionary
-var keep_action := false
 var done := false:
 	get:
 		return done
@@ -149,11 +148,3 @@ func set_done_false():
 
 func zero_reward():
 	reward = 0.0
-
-
-func get_keep_action():
-	return keep_action
-
-
-func set_keep_action(v):
-	keep_action = v

--- a/addons/godot_rl_agents/sensors/sensors_2d/RaycastSensor2D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_2d/RaycastSensor2D.gd
@@ -43,7 +43,7 @@ class_name RaycastSensor2D
 		cone_width = value
 		_update()
 
-@export var debug_draw := true:
+@export var debug_draw := false:
 	get:
 		return debug_draw
 	set(value):
@@ -56,20 +56,19 @@ var rays := []
 
 func _update():
 	if Engine.is_editor_hint():
-		if debug_draw:
+		if is_node_ready():
 			_spawn_nodes()
-		else:
-			for ray in get_children():
-				if ray is RayCast2D:
-					remove_child(ray)
-
 
 func _ready() -> void:
-	_spawn_nodes()
+	if Engine.is_editor_hint():
+		if get_child_count() == 0:
+			_spawn_nodes()
+	else:
+		_spawn_nodes()
 
 
 func _spawn_nodes():
-	for ray in rays:
+	for ray in get_children():
 		ray.queue_free()
 	rays = []
 
@@ -83,12 +82,16 @@ func _spawn_nodes():
 		ray.set_target_position(
 			Vector2(ray_length * cos(deg_to_rad(angle)), ray_length * sin(deg_to_rad(angle)))
 		)
-		ray.set_name("node_" + str(i))
-		ray.enabled = false
+		if debug_draw:
+			ray.enabled = true
+		else:
+			ray.enabled = false
 		ray.collide_with_areas = collide_with_areas
 		ray.collide_with_bodies = collide_with_bodies
 		ray.collision_mask = collision_mask
 		add_child(ray)
+		ray.set_owner(get_tree().edited_scene_root)
+		ray.set_name("node_" + str(i))
 		rays.append(ray)
 
 		_angles.append(start + i * step)
@@ -101,11 +104,13 @@ func get_observation() -> Array:
 func calculate_raycasts() -> Array:
 	var result = []
 	for ray in rays:
-		ray.enabled = true
+		if not debug_draw:
+			ray.enabled = true
 		ray.force_raycast_update()
 		var distance = _get_raycast_distance(ray)
 		result.append(distance)
-		ray.enabled = false
+		if not debug_draw:
+			ray.enabled = false
 	return result
 
 

--- a/addons/godot_rl_agents/sensors/sensors_3d/RaycastSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RaycastSensor3D.gd
@@ -170,7 +170,7 @@ func get_observation() -> Array:
 func calculate_raycasts() -> Array:
 	var result = []
 	for ray in rays:
-		if debug_draw:
+		if not debug_draw:
 			ray.set_enabled(true)
 		ray.force_raycast_update()
 		var distance = _get_raycast_distance(ray)
@@ -183,7 +183,7 @@ func calculate_raycasts() -> Array:
 				hit_collision_layer = hit_collision_layer & collision_mask
 				hit_class = (hit_collision_layer & boolean_class_mask) > 0
 			result.append(float(hit_class))
-		if debug_draw:
+		if not debug_draw:
 			ray.set_enabled(false)
 	return result
 

--- a/addons/godot_rl_agents/sensors/sensors_3d/RaycastSensor3D.gd
+++ b/addons/godot_rl_agents/sensors/sensors_3d/RaycastSensor3D.gd
@@ -65,6 +65,13 @@ class_name RayCastSensor3D
 
 @export var class_sensor := false
 
+@export var debug_draw := false:
+	get:
+		return debug_draw
+	set(value):
+		debug_draw = value
+		_update()
+
 var rays := []
 var geo = null
 
@@ -111,13 +118,16 @@ func _spawn_nodes():
 
 			points.append(cast_to)
 
-			ray.set_name("node_" + str(i) + " " + str(j))
-			ray.enabled = true
+			if debug_draw:
+				ray.enabled = true
+			else:
+				ray.enabled = false
 			ray.collide_with_bodies = collide_with_bodies
 			ray.collide_with_areas = collide_with_areas
 			ray.collision_mask = collision_mask
 			add_child(ray)
 			ray.set_owner(get_tree().edited_scene_root)
+			ray.set_name("node_" + str(i) + " " + str(j))
 			rays.append(ray)
 			ray.force_raycast_update()
 
@@ -160,7 +170,8 @@ func get_observation() -> Array:
 func calculate_raycasts() -> Array:
 	var result = []
 	for ray in rays:
-		ray.set_enabled(true)
+		if debug_draw:
+			ray.set_enabled(true)
 		ray.force_raycast_update()
 		var distance = _get_raycast_distance(ray)
 
@@ -172,7 +183,8 @@ func calculate_raycasts() -> Array:
 				hit_collision_layer = hit_collision_layer & collision_mask
 				hit_class = (hit_collision_layer & boolean_class_mask) > 0
 			result.append(float(hit_class))
-		ray.set_enabled(false)
+		if debug_draw:
+			ray.set_enabled(false)
 	return result
 
 

--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -190,8 +190,9 @@ func _physics_process(_delta):
 	if n_action_steps % action_repeat != 0:
 		if connected and _check_done_from_agents(agents_training):
 			# At least one of the agents has set done to true, initiate the learning asap
-			_set_agent_keep_action()
-			print("Train all agents but keep previous actions where necessary at n_action_steps: ", n_action_steps)
+			assert(not keep_action, "keep_action already set to true")
+			keep_action = true
+			print("Train all agents but keep previous action at n_action_steps: ", n_action_steps)
 		else:
 			n_action_steps += 1
 			return
@@ -534,8 +535,12 @@ func handle_message() -> bool:
 		return handle_message()
 
 	if message["type"] == "action":
-		var action = message["action"]
-		_set_agent_actions(action, agents_training)
+		if not keep_action:
+			var action = message["action"]
+			_set_agent_actions(action, agents_training)
+		else:
+			# keep the previously set action
+			keep_action = false
 		need_to_send_obs = true
 		get_tree().set_pause(false)
 		return true
@@ -603,6 +608,7 @@ func _get_done_from_agents(agents: Array = agents_training):
 
 
 func _check_done_from_agents(agents: Array = agents_training):
+	var dones = []
 	for agent in agents:
 		var done = agent.get_done()
 		if done:
@@ -610,24 +616,9 @@ func _check_done_from_agents(agents: Array = agents_training):
 	return false
 
 
-func _set_agent_keep_action(agents: Array = agents_training):
-	# this function must only be called when at least one of the agent has a done of true
-	for agent in agents:
-		var done = agent.get_done()
-		if not done:
-			# mark to keep the previously selected action when the action has not observed a terminal state (done is false)
-			assert(not agent.get_keep_action(), "keep_action already set to true")
-			agent.set_keep_action(true)
-
-
 func _set_agent_actions(actions, agents: Array = all_agents):
 	for i in range(len(actions)):
-		if agents[i].get_keep_action():
-			# keep the previously selected action
-			agents[i].set_keep_action(false)
-		else:
-			agents[i].set_action(actions[i])
-			
+		agents[i].set_action(actions[i])
 
 
 func clamp_array(arr: Array, min: float, max: float):

--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -54,6 +54,7 @@ var initialized = false
 var just_reset = false
 var onnx_model = null
 var n_action_steps = 0
+var keep_action = false
 
 var _action_space_training: Array[Dictionary] = []
 var _action_space_inference: Array[Dictionary] = []
@@ -187,8 +188,14 @@ func _physics_process(_delta):
 	_demo_record_process()
 
 	if n_action_steps % action_repeat != 0:
-		n_action_steps += 1
-		return
+		if connected and _check_done_from_agents(agents_training):
+			# At least one of the agents has set done to true, initiate the learning asap
+			assert(not keep_action, "keep_action already set to true")
+			keep_action = true
+			print("Train all agents but keep previous action at n_action_steps: ", n_action_steps)
+		else:
+			n_action_steps += 1
+			return
 
 	n_action_steps += 1
 
@@ -217,7 +224,6 @@ func _training_process():
 			need_to_send_obs = false
 			var reward = _get_reward_from_agents()
 			var done = _get_done_from_agents()
-			#_reset_agents_if_done() # this ensures the new observation is from the next env instance : NEEDS REFACTOR
 
 			var reply = {"type": "step", "obs": obs, "reward": reward, "done": done, "info": info}
 			_send_dict_as_json_message(reply)
@@ -529,8 +535,12 @@ func handle_message() -> bool:
 		return handle_message()
 
 	if message["type"] == "action":
-		var action = message["action"]
-		_set_agent_actions(action, agents_training)
+		if not keep_action:
+			var action = message["action"]
+			_set_agent_actions(action, agents_training)
+		else:
+			# keep the previously set action
+			keep_action = false
 		need_to_send_obs = true
 		get_tree().set_pause(false)
 		return true
@@ -562,7 +572,13 @@ func _reset_agents(agents = all_agents):
 func _get_obs_from_agents(agents: Array = all_agents):
 	var obs = []
 	for agent in agents:
-		obs.append(agent.get_obs())
+		if agent.get_done():
+			# get the observation when the terminal state was observed (done was set to true)
+			var t_obs = agent.get_obs_done()
+			assert(t_obs != {}, "obs_done must not be empty")
+			obs.append(t_obs)
+		else:
+			obs.append(agent.get_obs())
 	return obs
 
 
@@ -589,6 +605,15 @@ func _get_done_from_agents(agents: Array = agents_training):
 			agent.set_done_false()
 		dones.append(done)
 	return dones
+
+
+func _check_done_from_agents(agents: Array = agents_training):
+	var dones = []
+	for agent in agents:
+		var done = agent.get_done()
+		if done:
+			return true
+	return false
 
 
 func _set_agent_actions(actions, agents: Array = all_agents):

--- a/addons/godot_rl_agents/sync.gd
+++ b/addons/godot_rl_agents/sync.gd
@@ -190,9 +190,8 @@ func _physics_process(_delta):
 	if n_action_steps % action_repeat != 0:
 		if connected and _check_done_from_agents(agents_training):
 			# At least one of the agents has set done to true, initiate the learning asap
-			assert(not keep_action, "keep_action already set to true")
-			keep_action = true
-			print("Train all agents but keep previous action at n_action_steps: ", n_action_steps)
+			_set_agent_keep_action()
+			print("Train all agents but keep previous actions where necessary at n_action_steps: ", n_action_steps)
 		else:
 			n_action_steps += 1
 			return
@@ -535,12 +534,8 @@ func handle_message() -> bool:
 		return handle_message()
 
 	if message["type"] == "action":
-		if not keep_action:
-			var action = message["action"]
-			_set_agent_actions(action, agents_training)
-		else:
-			# keep the previously set action
-			keep_action = false
+		var action = message["action"]
+		_set_agent_actions(action, agents_training)
 		need_to_send_obs = true
 		get_tree().set_pause(false)
 		return true
@@ -608,7 +603,6 @@ func _get_done_from_agents(agents: Array = agents_training):
 
 
 func _check_done_from_agents(agents: Array = agents_training):
-	var dones = []
 	for agent in agents:
 		var done = agent.get_done()
 		if done:
@@ -616,9 +610,24 @@ func _check_done_from_agents(agents: Array = agents_training):
 	return false
 
 
+func _set_agent_keep_action(agents: Array = agents_training):
+	# this function must only be called when at least one of the agent has a done of true
+	for agent in agents:
+		var done = agent.get_done()
+		if not done:
+			# mark to keep the previously selected action when the action has not observed a terminal state (done is false)
+			assert(not agent.get_keep_action(), "keep_action already set to true")
+			agent.set_keep_action(true)
+
+
 func _set_agent_actions(actions, agents: Array = all_agents):
 	for i in range(len(actions)):
-		agents[i].set_action(actions[i])
+		if agents[i].get_keep_action():
+			# keep the previously selected action
+			agents[i].set_keep_action(false)
+		else:
+			agents[i].set_action(actions[i])
+			
 
 
 func clamp_array(arr: Array, min: float, max: float):


### PR DESCRIPTION
**Improved RayCastSensor2D/3D debugging:**
- Ray collisions in RayCastSensor2D now visible when debug_draw is set to true
- Child nodes in RayCastSensor2D visible in scene tree (similar to RayCastSensor3D)
- Fixed names of child nodes in RayCastSensor3D (names cannot be set reliably before setting the owner)
- Default for debug_draw is false for RayCastSensor2D + RayCastSensor3D nodes

**What is the issue with the observations:**
- Usually when a terminal state is observed then in the environments needs_reset and done are both set to true (e.g. see RingPong example)
- Then, in the next call to _physics_process() of the player, usually the AI-controller and the game is reset
- However, because _physics_process() of sync is called afterwards, this causes the problem that the observation is retrieved from the resetted-game during the learning (see _training_process()) and this does not match the observation when done was set to true (so it is one observation ahead)
- Furthermore, when repeated actions are utilized, then the observations retrieved in _physics_process() of sync are even more ahead (so the problem is getting worse)

**How this is fixed:**
- The observation is immediately stored and kept when done is set to true (all happens per agent/environment)
- The training is issued when at least one of the agents has set done to true, irrespective of the repeat action mechanism
- However, the repeat action mechanism stays intact, i.e. when the training is issued before the usual time (e.g. on every 8th step when repeated actions is set to 8) then the actions are repeated for the agents that were not yet visiting a terminal state

